### PR TITLE
Fix layout jumps in control area

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,23 @@
       margin-top: 5px;
       font-size: 0.9em;
       color: #555;
+      min-height: 1.2em;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     #controles {
       display: none;
-      margin-top: 15px;
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: rgba(255,255,255,0.9);
+      border: 1px solid #ccc;
+      padding: 10px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+      border-radius: 4px;
+      z-index: 1000;
+      max-width: 300px;
     }
     #typeContainer {
       margin-top: 10px;

--- a/linux_helpers.py
+++ b/linux_helpers.py
@@ -169,7 +169,7 @@ def _get_window_geometry_xdotool(display, window_id):
     return (x, y, width, height)
 
 
-def capture_window_linux(session_info, out_path):
+def capture_window_linux(session_info, out_path=None):
     """
     Captura la ventana completa de Chrome y devuelve un BytesIO con JPEG en memoria.
       1) Verifica que el proceso de Chrome siga vivo.
@@ -177,7 +177,7 @@ def capture_window_linux(session_info, out_path):
       3) Obtiene la geometría completa.
       4) Hace ImageGrab.grab(bbox=(x,y,x+width,y+height)) usando el DISPLAY.
       5) Genera un JPEG en un io.BytesIO (calidad 75) y lo retorna.
-      6) IGNORA 'out_path' (ya no se escribe PNG en disco).
+      6) IGNORA el parámetro opcional 'out_path' (ya no se escribe PNG en disco).
     """
     with lock:
         display = session_info["display"]

--- a/windows_helpers.py
+++ b/windows_helpers.py
@@ -110,11 +110,11 @@ def _get_window_rect_windows(hwnd):
 # ------------------------------------------------
 #  2. Capturar la ventana completa (ahora JPEG en memoria)
 # ------------------------------------------------
-def capture_window_windows(session_info, out_path):
+def capture_window_windows(session_info, out_path=None):
     """
     Usa PIL.ImageGrab.grab(bbox) para capturar la región completa de la ventana
     (obtiene coords con GetWindowRect). EN LUGAR DE GUARDAR PNG, convierte a JPEG en un
-    io.BytesIO y retorna ese buffer. 'out_path' se IGNORA.
+    io.BytesIO y retorna ese buffer. El parámetro opcional 'out_path' se IGNORA.
     Devuelve el io.BytesIO con JPEG (posición al inicio).
     """
     with lock:


### PR DESCRIPTION
## Summary
- refine `clickStatus` and `typeStatus` styles to reduce vertical jumps in the UI
- float control options in a fixed overlay to avoid layout shifts
- make capture helpers optional out_path to match remote.py

## Testing
- `python3 -m py_compile remote.py linux_helpers.py windows_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_6843481a884c83278ce9cd386abffc5a